### PR TITLE
declare an application so './gradlew run' works

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@
 plugins {
     id 'com.gradle.build-scan' version '1.9'
 	id 'java'
+	id 'application'
 	id 'eclipse'
 //  id 'maven' // comment this in and the next line out for populating to a local Maven repository for testing purposes
     id 'com.github.oehme.sobula.bintray-release' version '0.6.7'
@@ -16,6 +17,8 @@ plugins {
 
 ext.githubProjectUrl = 'https://github.com/JavaPOSWorkingGroup/javapos-config-editor'
 ext.travisProjectUrl = 'https://travis-ci.org/JavaPOSWorkingGroup/javapos-config-editor'
+
+mainClassName = 'jpos.config.simple.editor.JposEntryEditor'
 
 buildScan {
     licenseAgreementUrl = 'https://gradle.com/terms-of-service'


### PR DESCRIPTION
Tell gradle that this is an application, and where its main class is.

This allows users to `./gradlew run` and the app starts, with the classpath configured automatically.